### PR TITLE
Avoid using deprecated getCategories

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -219,7 +219,16 @@ class Hooks {
 
 		// we can remove the categories by save/restore
 		if ( $reset['categories'] ?? false ) {
-			$saveCategories = $parser->getOutput()->getCategories();
+			$parserOutput = $parser->getOutput();
+			if ( method_exists( $parserOutput, 'getCategoryNames' ) && method_exists( $parserOutput, 'getCategorySortKey' ) ) {
+				$saveCategories = array_combine(
+					$parserOutput->getCategoryNames(),
+					// @phan-suppress-next-line PhanUndeclaredMethod
+					array_map( fn ( $value ) => $parserOutput->getCategorySortKey( $value ), $parserOutput->getCategoryNames() )
+				);
+			} else {
+				$saveCategories = $parserOutput->getCategories();
+			}
 		}
 
 		// we can remove the images by save/restore
@@ -556,9 +565,18 @@ class Hooks {
 		if ( !self::$createdLinks['resetdone'] ) {
 			self::$createdLinks['resetdone'] = true;
 
-			foreach ( $parser->getOutput()->getCategories() as $key => $val ) {
-				if ( array_key_exists( $key, self::$fixedCategories ) ) {
-					self::$fixedCategories[$key] = $val;
+			if ( method_exists( $parser->getOutput(), 'getCategoryNames' ) && method_exists( $parser->getOutput(), 'getCategorySortKey' ) ) {
+				foreach ( $parser->getOutput()->getCategoryNames() as $key ) {
+					if ( array_key_exists( $key, self::$fixedCategories ) ) {
+						// @phan-suppress-next-line PhanUndeclaredMethod
+						self::$fixedCategories[$key] = $parser->getOutput()->getCategorySortKey( $key );
+					}
+				}
+			} else {
+				foreach ( $parser->getOutput()->getCategories() as $key => $val ) {
+					if ( array_key_exists( $key, self::$fixedCategories ) ) {
+						self::$fixedCategories[$key] = $val;
+					}
 				}
 			}
 
@@ -618,7 +636,17 @@ class Hooks {
 			}
 
 			if ( isset( self::$createdLinks ) && array_key_exists( 2, self::$createdLinks ) ) {
-				$parser->getOutput()->setCategories( array_diff_assoc( $parser->getOutput()->getCategories(), self::$createdLinks[2] ) );
+				$parserOutput = $parser->getOutput();
+				if ( method_exists( $parserOutput, 'getCategoryNames' ) && method_exists( $parserOutput, 'getCategorySortKey' ) ) {
+					$categories = array_combine(
+						$parserOutput->getCategoryNames(),
+						// @phan-suppress-next-line PhanUndeclaredMethod
+						array_map( fn ( $value ) => $parserOutput->getCategorySortKey( $value ), $parserOutput->getCategoryNames() )
+					);
+					$parser->getOutput()->setCategories( array_diff_assoc( $categories, self::$createdLinks[2] ) );
+				} else {
+					$parser->getOutput()->setCategories( array_diff_assoc( $parserOutput->getCategories(), self::$createdLinks[2] ) );
+				}
 			}
 
 			if ( isset( self::$createdLinks ) && array_key_exists( 3, self::$createdLinks ) ) {


### PR DESCRIPTION
getCategories has been deprecated since 1.40 and is removed in MW master branch.

Follow-up: I8dc85e76bfbb9ed49a603d990c14b7ee798bd821
Follow-up: I7b8a86f6efbdd86c1f493db6741c37bfb325e9bb
Signed-off-by: xtex <xtexchooser@duck.com>