### PR TITLE
Fix infinite loop if section header has (

### DIFF
--- a/includes/LST.php
+++ b/includes/LST.php
@@ -480,9 +480,7 @@ class LST {
 				}
 
 				if ( preg_match( "/$pat/im", $text, $m, PREG_OFFSET_CAPTURE ) ) {
-					$mata = [];
-					$no_parenthesis = preg_match_all( '/\(/', $pat, $mata );
-					$begin_off = $m[$no_parenthesis][1];
+					$begin_off = end($m)[1];
 					$head_len = strlen( $m[1][0] );
 					$headLine = trim( $m[0][0], "\n =\t" );
 				} elseif ( $nr == -2 ) {
@@ -559,6 +557,11 @@ class LST {
 				if ( $sec == '' ) {
 					$continueSearch = false;
 				} else {
+					if ( $end_off == 0 ) {
+						// we have made no progress - something has gone wrong, but at least don't loop forever
+						break;
+					}
+					// this could lead to quadratic runtime...
 					$text = substr( $text, $end_off );
 				}
 			} else {


### PR DESCRIPTION
There is a nasty infinite loop bug here, where any section `include` with a `(` in it will cause the code to run until timeout.

As far as I can tell, the intent of the original author in 2009 was:
- use the position of the last capture group of `$pat` ($) to determine the length of the header match
- normally this would always be the second capture group, so indexing at $m[2] should work
- however, because section includes can match on regex, and this regex could also itself include capture groups, ($) might not actually be the 2nd capture group
- in order to mitigate this, the original author confusingly does a regex match on `$pat` (which is, itself, a regex) to count up the number of parentheses in the pattern
- ignoring that there are much better ways to count up the number of parentheses in a string, there is a larger problem: this heuristic fails if the number of parentheses is not the same as the number of capture groups (for example, if there is just a parenthesis literal, due to trying to match a section name with a `(` in it)
- as a result, `$m[$no_parenthesis]` indexes an out-of-bounds element of the array, and the loop iteration makes no progress, repeating until exhaustion.

because `($)` will always be the last capture group...just do `end($m)` and call it a day. I also added a bit of logic to try to break if we get into other scenarios where no progress is made in the loop iteration.